### PR TITLE
Fix MenuItem click crash

### DIFF
--- a/WpfPilot.ExampleApp/MainWindow.xaml
+++ b/WpfPilot.ExampleApp/MainWindow.xaml
@@ -25,6 +25,13 @@
 		</ListBox>
 		<TextBox Name="TextBox1" Height="30" Width="200" Text="Hello! I am a TextBox." Margin="118,216,482,188" TextChanged="TextBox1_TextChanged" GotKeyboardFocus="TextBox1_GotKeyboardFocus" TouchDown="TextBox1_TouchDown" SelectionChanged="TextBox1_SelectionChanged">
 		</TextBox>
+		<Menu Margin="313,391,374,116">
+			<MenuItem Header="Menu Header">
+				<MenuItem Header="MenuItemOne" IsCheckable="True" />
+				<Separator/>
+				<MenuItem Header="MenuItemTwo" />
+			</MenuItem>
+		</Menu>
 		<Expander Name="ExpanderControl" HorizontalAlignment="Left" Background="LavenderBlush" ExpandDirection="Down"  IsExpanded="False" Width="250" FontSize="20" FontWeight="Bold" Foreground="Green" Height="200" Margin="540,10,0,254" Expanded="ExpanderControl_Expanded" Collapsed="ExpanderControl_Collapsed">
 			<Expander.Content>
 				<ScrollViewer Name="ScrollViewer" Height="100" VerticalAlignment="Top">

--- a/WpfPilot.Tests/ElementTests.cs
+++ b/WpfPilot.Tests/ElementTests.cs
@@ -64,6 +64,10 @@ public sealed class ElementTests : AppTestBase
 			.Collapse()
 			.Assert(_ => eventDisplay["Text"] == "ExpanderControl_Collapsed event triggered.");
 
+		// Test menus.
+		appDriver.GetElement(x => x["Header"] == "Menu Header").Click();
+		appDriver.GetElement(x => x["Header"] == "MenuItemOne").Click().Assert(x => x["IsChecked"] == true);
+
 		// Test ScrollIntoView.
 		var scrollViewer = appDriver.GetElement<MyScrollViewer>(x => x["Name"] == "ScrollViewer");
 		var initialOffset = scrollViewer["VerticalOffset"];

--- a/WpfPilot/AppDriverPayload/ControlHooks.cs
+++ b/WpfPilot/AppDriverPayload/ControlHooks.cs
@@ -88,16 +88,12 @@ internal static class ControlHooks
 		public static bool Prefix(ButtonBase __instance)
 		{
 			var isPressed = (bool) typeof(ButtonBase).GetProperty("IsPressed", Flags).GetValue(__instance);
-			var setIsPressed = typeof(ButtonBase).GetMethod("SetIsPressed", Flags);
+			var methods = ReflectionUtility.GetCandidateMethods(typeof(ButtonBase), "SetIsPressed", Flags, new object[] { true });
 
 			if (!isPressed)
-			{
-				setIsPressed.Invoke(__instance, new object[] { true });
-			}
+				ReflectionUtility.FindAndInvokeBestMatch(methods, __instance, new object[] { true });
 			else if (isPressed)
-			{
-				setIsPressed.Invoke(__instance, new object[] { false });
-			}
+				ReflectionUtility.FindAndInvokeBestMatch(methods, __instance, new object[] { false });
 
 			return false;
 		}
@@ -125,7 +121,10 @@ internal static class ControlHooks
 			MenuItemRole role = (MenuItemRole) typeof(MenuItem).GetProperty("Role", Flags).GetValue(__instance);
 
 			if (role == MenuItemRole.TopLevelHeader || role == MenuItemRole.SubmenuHeader)
-				typeof(MenuItem).GetMethod("ClickHeader", Flags).Invoke(__instance, null);
+			{
+				var methods = ReflectionUtility.GetCandidateMethods(typeof(MenuItem), "ClickHeader", Flags, null);
+				ReflectionUtility.FindAndInvokeBestMatch(methods, __instance, null);
+			}
 
 			// Handle mouse messages b/c they were over me, I just didn't use it
 			e.Handled = true;
@@ -144,7 +143,10 @@ internal static class ControlHooks
 			MenuItemRole role = (MenuItemRole) typeof(MenuItem).GetProperty("Role", Flags).GetValue(__instance);
 
 			if (role == MenuItemRole.TopLevelItem || role == MenuItemRole.SubmenuItem)
-				typeof(MenuItem).GetMethod("ClickItem", Flags).Invoke(__instance, new object[] { true });
+			{
+				var methods = ReflectionUtility.GetCandidateMethods(typeof(MenuItem), "ClickItem", Flags, new object[] { true });
+				ReflectionUtility.FindAndInvokeBestMatch(methods, __instance, new object[] { true });
+			}
 
 			if (e.ChangedButton != MouseButton.Right)
 			{


### PR DESCRIPTION
`ClickItem` seemed to have multiple candidate methods, which triggered a crash. The `ReflectionUtility` properly handles such cases.