### PR TITLE
Fix ShowDialog blocking WPF Pilot

### DIFF
--- a/WpfPilot/AppDriverPayload/AppDriverPayload.cs
+++ b/WpfPilot/AppDriverPayload/AppDriverPayload.cs
@@ -25,8 +25,8 @@ public static class AppDriverPayload
 		var pipeName = split[0];
 		var dllPath = split[1];
 
-		var hasUIThreadAccess = RunOnUIThread(rootObject => Task.FromResult(true));
-		if (hasUIThreadAccess == UIThreadRunResult.Unable)
+		var testRun = RunOnUIThread(rootObject => Task.FromResult(true));
+		if (testRun == UIThreadRunResult.Unable)
 			Exit("Injected into a non-UI thread. This could happen if the app has a boot up screen phase, or the like.");
 
 		try

--- a/WpfPilot/AppDriverPayload/AppDriverPayload.cs
+++ b/WpfPilot/AppDriverPayload/AppDriverPayload.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using WpfPilot.AppDriverPayload.Commands;
 using WpfPilot.Interop;
 using WpfPilot.Utility;

--- a/WpfPilot/AppDriverPayload/AppHooks.cs
+++ b/WpfPilot/AppDriverPayload/AppHooks.cs
@@ -207,10 +207,10 @@ internal static class AppHooks
 	[HarmonyPatch(typeof(Window), "ShowDialog")]
 	public static class PatchWindowShowDialog
 	{
+		// We need a way to know if `ShowDialog` was called, to avoid blocking.
 		public static bool Prefix(Window __instance)
 		{
 			AppHooks.ShowDialogCalled = true;
-			Log.Info($"PatchWindowShowDialog.Prefix. ShowDialogCalled: {AppHooks.ShowDialogCalled}.");
 			return true;
 		}
 	}

--- a/WpfPilot/Interop/NamedPipeServer.cs
+++ b/WpfPilot/Interop/NamedPipeServer.cs
@@ -36,6 +36,8 @@ internal sealed class NamedPipeServer : IDisposable
 
 		void Respond(dynamic response)
 		{
+			if (hasResponded)
+				return;
 			var writer = new StreamWriter(Pipe);
 			var r = MessagePacker.Pack(response);
 			writer.Write(r);


### PR DESCRIPTION
Issue:
Calling `otherWindow.ShowDialog()` was blocking the AppPayload command loop. This fixes that problem.
I doubt this is the most elegant or best solution, but it's straightforward and works.