### PR TITLE
Simplify Keyboard module

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Assert.True(playerHUD["PlayerName"].StartsWith("Erik"));
 
 - `Keyboard.Press`
 - `Keyboard.Type`
-- `Keyboard.Hotkey`
 
 ## CI/CD
 
@@ -153,3 +152,4 @@ The WPF Pilot split license is viewable [here](LICENSE.txt). For most consumers 
 - If you cloned the project, and built in debug locally, and `AppDriverPayload` is injected into an exe, you can attach Visual Studio to the process and walk through the `AppDriverPayload` code like usual.
 - `WpfPilot` uses DLL injection to setup a communication bridge. If you have an aggressive anti-virus, you may need to disable it. I have never personally encountered this, but it is worth mentioning.
 - If the app is launched in Administrator mode, and the test suite is not, it may not have permissions to inject.
+- The test suite dotnet version or framework must match the application dotnet version or framework.

--- a/WpfPilot.Tests/ElementTests.cs
+++ b/WpfPilot.Tests/ElementTests.cs
@@ -80,7 +80,7 @@ public sealed class ElementTests : AppTestBase
 
 		// Test other windows.
 		appDriver.GetElement(x => x["Content"] == "Open a message box").Click();
-		appDriver.Keyboard.PhysicalPress(System.Windows.Input.Key.Tab, System.Windows.Input.Key.Enter);
+		appDriver.Keyboard.Press(System.Windows.Input.Key.Tab, System.Windows.Input.Key.Enter);
 		appDriver.GetElement(x => x["Content"] == "Open other window").Click();
 		appDriver.GetElement(x => x.TypeName == "CheckBox" && x["Content"] == "CoolCheckBox").Click().Assert(x => x["IsChecked"] == true);
 

--- a/WpfPilot.Tests/KeyboardTests.cs
+++ b/WpfPilot.Tests/KeyboardTests.cs
@@ -23,7 +23,7 @@ public sealed class KeyboardTests : AppTestBase
 		using var appDriver = AppDriver.Launch(ExePath);
 		var eventDisplay = appDriver.GetElement(x => x["Name"] == "EventDisplay");
 
-		appDriver.Keyboard.Hotkey(ModifierKeys.Control, Key.A);
+		appDriver.Keyboard.Press(Key.LeftCtrl, Key.A);
 		Assert.AreEqual("Ctrl+A shortcut triggered.", eventDisplay["Text"]);
 
 		var textbox = appDriver.GetElement(x => x["Name"] == "TextBox1");

--- a/WpfPilot.Tests/KeyboardTests.cs
+++ b/WpfPilot.Tests/KeyboardTests.cs
@@ -30,11 +30,11 @@ public sealed class KeyboardTests : AppTestBase
 		textbox["Text"] = "";
 		textbox.Focus();
 
-		appDriver.Keyboard.Type("This is a quick typing test. 😊");
-		Assert.AreEqual("This is a quick typing test. 😊", textbox["Text"]);
+		appDriver.Keyboard.Type("This is a quick typing test. ");
+		Assert.AreEqual("This is a quick typing test. ", textbox["Text"]);
 
-		appDriver.Keyboard.Press(Key.H, Key.I);
-		Assert.AreEqual("This is a quick typing test. 😊HI", textbox["Text"]);
+		appDriver.Keyboard.Press(Key.LeftShift, Key.H, Key.I);
+		Assert.AreEqual("This is a quick typing test. HI", textbox["Text"]);
 	}
 
 	public string ExePath { get; private set; } = "";

--- a/WpfPilot/AppDriver.cs
+++ b/WpfPilot/AppDriver.cs
@@ -49,7 +49,7 @@ public sealed class AppDriver : IDisposable
 				AppProcess.Process.Refresh();
 				Injector.InjectAppDriver(AppProcess, pipeName, dllRootDirectory);
 			});
-		Keyboard = new Keyboard(Channel, AppProcess.Process, OnAction);
+		Keyboard = new Keyboard(OnAction);
 		TargetIdToElement = new Dictionary<string, List<Element>>(capacity: 1_000); // Start with a decent capacity.
 
 		// This is the default set of properties we retrieve, however devs can add more properties to this set.

--- a/WpfPilot/Keyboard.cs
+++ b/WpfPilot/Keyboard.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using WpfPilot.Utility;
 using WpfPilot.Utility.WindowsAPI;
@@ -51,6 +52,9 @@ public sealed class Keyboard
 			// Press and release the regular key
 			SendInput(virtualKey, true, false, false, false);
 			SendInput(virtualKey, false, false, false, false);
+
+			// Mechanical typing speed. Gives the application time to handle the inputs.
+			Task.Delay(millisecondsDelay: 50).GetAwaiter().GetResult();
 		}
 
 		// Release all held modifiers in reverse order
@@ -111,6 +115,9 @@ public sealed class Keyboard
 				// Release shift
 				SendInput(User32.VK_SHIFT, false, false, false, false);
 			}
+
+			// Mechanical typing speed. Gives the application time to handle the inputs.
+			Task.Delay(millisecondsDelay: 20).GetAwaiter().GetResult();
 		}
 
 		OnAction();

--- a/WpfPilot/Utility/WindowsAPI/User32.cs
+++ b/WpfPilot/Utility/WindowsAPI/User32.cs
@@ -1,4 +1,6 @@
-﻿namespace WpfPilot.Utility.WindowsAPI;
+﻿#pragma warning disable SA1310 // Field names should not contain underscore
+
+namespace WpfPilot.Utility.WindowsAPI;
 
 using System;
 using System.Runtime.InteropServices;
@@ -144,6 +146,7 @@ internal static class User32
 	[DllImport("kernel32.dll", SetLastError = true)]
 	public static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress,
 		byte[] lpBuffer, int nSize, out IntPtr lpNumberOfBytesWritten);
+
+	public const byte VK_SHIFT = 0x10;
 }
 #pragma warning restore
-


### PR DESCRIPTION
- [x] Delete redundant or overlapping methods.
- [x] Work in more scenarios.

This is a **breaking change**. Behavior is slightly different and certain methods are removed or renamed.